### PR TITLE
Fixed Error : Missing privilege separation directory: /run/sshd

### DIFF
--- a/rootfs/entrypoint.sh
+++ b/rootfs/entrypoint.sh
@@ -2,6 +2,7 @@
 
 # Generate host keys if not present
 ssh-keygen -A
+mkdir -p /run/sshd
 
 # Set root password to empty
 SSH_ROOT_PASSWORD="$SSH_ROOT_PASSWORD"


### PR DESCRIPTION
Error Message
```sh
ssh-keygen: generating new host keys: DSA 
Missing privilege separation directory: /run/sshd
```

Reference: https://github.com/microsoft/WSL/issues/3621